### PR TITLE
Uses angular.noop as default controller for mocked directives

### DIFF
--- a/src/mox.js
+++ b/src/mox.js
@@ -263,7 +263,7 @@ function MoxBuilder() {
             template: mock.template || undefined,
             templateUrl: mock.templateUrl || undefined,
             transclude: mock.transclude || undefined,
-            controller: mock.controller || undefined,
+            controller: mock.controller || angular.noop,
             compile: mock.compile || undefined,
             link: mock.link || undefined
           });

--- a/test/spec/mox-spec.js
+++ b/test/spec/mox-spec.js
@@ -299,7 +299,7 @@ describe('The Mox library', function () {
           key: '='
         },
         require: undefined,
-        controller: undefined,
+        controller: angular.noop,
         templateUrl: undefined,
         template: undefined,
         link: undefined,

--- a/test/spec/mox-spec.js
+++ b/test/spec/mox-spec.js
@@ -60,6 +60,11 @@ describe('The Mox library', function () {
           template: '<div>Directive 2</div>'
         };
       })
+      .component('component1', {
+        bindings: {
+          key: '<'
+        }
+      })
       .factory('factory', function () {
         return {
           methodA: function () {
@@ -309,6 +314,19 @@ describe('The Mox library', function () {
         index: 0,
         restrict: 'AE'
       }));
+    });
+
+    it('should mock directives/components that use bindToController properly so isolate scope properties can be bound', function () {
+      mox
+        .module('test')
+        .mockDirectives('component1')
+        .run();
+
+      var $scope = createScope({
+        keyValue: 'foo'
+      });
+      var element = compileHtml('<component1 key="keyValue"></component1>', $scope);
+      expect(element.isolateScope().$ctrl.key).toEqual($scope.keyValue);
     });
 
     it('should mock a the first registered directive with a newly defined version with some additional properties (name, scope, restrict and priority are not overwritable)', function () {


### PR DESCRIPTION
Use an empty function instead of undefined so bindToController doesn't break in later angular versions
