### PR TITLE
Add support for $controller's bindings parameter

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -54,10 +54,13 @@ function createScope(params) {
  * @param {string} ctrlName controller to create
  * @param {Object} $scope to inject into the created controller. If not given, look if there is a scope created with createScope().
  * @param {Object} [locals] optional local injections
+ * @param {Object} [bindings] optional bindings parameter, for testing controllers of directives that use `bindToController`
  * @returns {*}
  */
-function createController(ctrlName, $scope, locals) {
-  return mox.inject('$controller')(ctrlName, angular.extend({ $scope: $scope || currentSpec.$scope }, locals || {}));
+function createController(ctrlName, $scope, locals, bindings) {
+  var scope = $scope || currentSpec.$scope;
+  var combinedLocals = angular.extend({ $scope: scope }, locals || {});
+  return mox.inject('$controller')(ctrlName, combinedLocals, bindings);
 }
 
 /*********************

--- a/test/spec/helpers-spec.js
+++ b/test/spec/helpers-spec.js
@@ -85,6 +85,11 @@ describe('The helper functions', function () {
         var controller = createController('FooController', createScope(), { FooService: 'mocked service' });
         expect(controller.FooService).toBe('mocked service');
       });
+
+      it('should pass bindings if passed', function () {
+        var controller = createController('FooController', createScope(), { FooService: 'mocked service' }, { binding: 42 });
+        expect(controller.binding).toBe(42);
+      });
     });
   });
 


### PR DESCRIPTION
see https://docs.angularjs.org/api/ngMock/service/$controller for more information. Really missing this feature atm.
